### PR TITLE
Move rat plugin to strict profile

### DIFF
--- a/compilers/lesscss/pom.xml
+++ b/compilers/lesscss/pom.xml
@@ -127,14 +127,6 @@
               <exclude>src/main/resources/startup/favicon.svg</exclude>
             </excludes>
           </configuration>
-          <executions>
-            <execution>
-              <phase>verify</phase>
-              <goals>
-                <goal>check</goal>
-              </goals>
-            </execution>
-          </executions>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Move apache-rat-plugin behind the strict Maven profile so it only runs with -P strict, not on normal builds.